### PR TITLE
Unpin development dependencies

### DIFF
--- a/aaf-secure_headers.gemspec
+++ b/aaf-secure_headers.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'secure_headers'
   spec.add_dependency 'activesupport'
 
-  spec.add_development_dependency 'bundler', '~> 1.12'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
+  spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'actionpack'
 end


### PR DESCRIPTION
This resolves CVE-2020-8130 by requiring Rake to be updated to the latest version.