### PR TITLE
fix: Content Security Policy directive form-action blocks resource

### DIFF
--- a/lib/aaf/secure_headers.rb
+++ b/lib/aaf/secure_headers.rb
@@ -28,7 +28,7 @@ module AAF
         default_src: ["'none'"],
         base_uri: ["'none'"],
         font_src: ["'self'", 'https://fonts.gstatic.com'],
-        form_action: ["'self'"],
+        form_action: ["'self'", 'https://*.aaf.edu.au/auth/auth/openid_connect'],
         frame_ancestors: ["'none'"],
         img_src: ["'self'", 'data:'],
         script_src: ["'self'"],

--- a/lib/aaf/secure_headers/version.rb
+++ b/lib/aaf/secure_headers/version.rb
@@ -1,5 +1,5 @@
 module AAF
   module SecureHeaders
-    VERSION = '3.0.0'.freeze
+    VERSION = '3.1.0'.freeze
   end
 end


### PR DESCRIPTION
Hi team,

This PR resolves: [#1035](https://github.com/ausaccessfed/rapid-idp/issues/1035).

Rapid IdP Manager's CSP is allowlist-based, so resources must be listed in the allowlist in order to be accessed. Due to inconsistency in how different browsers implement [CSP: form-action](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action). Chrome and MS Edge block resource `https://rapididp.<ENV>.aaf.edu.au/auth/auth/openid_connect`, which stops users from logging into RIdP Manager. However, Firefox and Safari do not block it.

The blocked resource  `https://rapididp.<ENV>.aaf.edu.au/auth/auth/openid_connect` (openid_connect log in) is trustworthy, so we can include this source in the CSP.

The fix is to add `https://*.aaf.edu.au/auth/auth/openid_connect` to the CSP directive `form-action`. 


Please note: this is an allowlist, so it is safe to other sites who might be using this gem.

