### PR TITLE
added logic to default to override but allow configuration to disable

### DIFF
--- a/lib/aaf/secure_headers.rb
+++ b/lib/aaf/secure_headers.rb
@@ -38,10 +38,10 @@ module AAF
     end
 
     class <<self
-      def development_mode!
+      def development_mode!(use_default_overrides: true)
         ensure_rails
         insert_dev_middleware
-        override_dev_configuration
+        override_dev_configuration if use_default_overrides
       end
 
       private

--- a/spec/aaf/secure_headers_spec.rb
+++ b/spec/aaf/secure_headers_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe AAF::SecureHeaders do
       spy(SecureHeaders::Configuration, csp: csp_config)
     end
 
+    let(:use_default_overrides) { true }
+
     before do
       allow(Rails).to receive_message_chain(:application, :config, :middleware)
         .and_return(middleware)
@@ -20,7 +22,18 @@ RSpec.describe AAF::SecureHeaders do
     end
 
     def run
-      subject.development_mode!
+      subject.development_mode!(use_default_overrides: use_default_overrides)
+    end
+
+    context 'when disabling default overrides' do
+      let(:use_default_overrides) { false }
+
+      it 'doesnt override the defaults' do
+        run
+        expect(secure_headers_config).not_to have_received(:hsts=).with(nil)
+        expect(csp_config).not_to have_received(:[]=)
+          .with(:upgrade_insecure_requests, false)
+      end
     end
 
     it 'raises an exception when Rails is undefined' do


### PR DESCRIPTION
Due to this change https://github.com/github/secure_headers/compare/v6.3.0...v6.3.1#diff-ff55cdb1936327a25bfb0fbbee26eb8f2605fb531efae094f98df095d8433c18

our dev environments will fail wiwth projects that call development_mode! multiple times or call development_mode! and then try to override again i.e validator